### PR TITLE
add: github action bot to the environment

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -38,6 +38,8 @@ inputs:
 runs:
   using: "composite"
   steps:
+    - run: bash $GITHUB_ACTION_PATH/prepare-environment.sh
+      shell: bash
     - run: bash $GITHUB_ACTION_PATH/update-toolchain.sh
       shell: bash
       env:

--- a/prepare-environment.sh
+++ b/prepare-environment.sh
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Set up GitHub's Environment
+
+# shellcheck disable=2129
+# Chaining the echos seems more readable.
+echo "GIT_AUTHOR_NAME=github-actions[bot]" >> "$GITHUB_ENV"
+echo "GIT_AUTHOR_EMAIL=<github-actions[bot]@users.noreply.github.com>" >> "$GITHUB_ENV"
+echo "GIT_COMMITTER_NAME=github-actions[bot]" >> "$GITHUB_ENV"
+echo "GIT_COMMITTER_EMAIL=<github-actions[bot]@users.noreply.github.com>" >> "$GITHUB_ENV"


### PR DESCRIPTION
Adds the GH action bot as the default committer.
Otherwise the action is run as the last person, that changed something in the cron file.

Closes #14