### PR TITLE
add base as a possible configuration input

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -22,6 +22,10 @@ inputs:
     description: 'GITHUB_TOKEN or a `repo` scoped Personal Access Token (PAT)'
     required: false
     default: ${{ github.token }}
+  base:
+    description: 'The GitHub base'
+    required: false
+    default: ${{ github.head_ref }}
   commit-msg:
     description: 'The message provided with the commit'
     required: false
@@ -54,6 +58,7 @@ runs:
         delete-branch: true
         title: ${{ inputs.pr-title }}
         labels: ${{ inputs.pr-labels }}
+        base: ${{ github.head_ref }}
         token: ${{ inputs.token }}
         body: |
           Automatic change by the [update-rust-toolchain](https://github.com/a-kenji/update-rust-toolchain) Github Action.


### PR DESCRIPTION
This might fix: https://github.com/a-kenji/update-rust-toolchain/issues/16#issuecomment-1245931032

Add the `head-ref` as default input.

Ref: https://github.com/peter-evans/autopep8/issues/59